### PR TITLE
meson.build: remove dunamai dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright 2023 Ledger SAS
+# Copyright 2025 H2Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +17,13 @@
 
 project(
     'svd', 'c',
-    meson_version: '>=1.3.0',
-    version: run_command('dunamai', 'from', 'git', '--style', 'semver', '--dirty', check: true)
-             .stdout().strip(),
+    meson_version: '>=1.4.0',
+    version : run_command('support/meson/version.sh', 'get-vcs', check: true).stdout().strip(),
     license: 'Apache-2.0',
     license_files: ['LICENSES/Apache-2.0.txt'],
 )
+
+meson.add_dist_script('support/meson/version.sh', 'set-dist', meson.project_version())
 
 pymod = import('python')
 fs = import('fs')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
+# SPDX-FileCopyrightText: 2025 H2Lab
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,4 +8,3 @@ xmlschema
 svd2json>=0.1.6
 jinja2
 jinja-cli
-dunamai

--- a/support/meson/version.sh
+++ b/support/meson/version.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# SPDX-FileCopyrightText: 2025 H2Lab
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$1" = "get-vcs" ]; then
+    git -C "$MESON_SOURCE_ROOT" describe --tags --dirty --always
+elif [ "$1" = "set-dist" ]; then
+    $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
+else
+    exit 1
+fi


### PR DESCRIPTION
This PR removes the need of an external dependency (i.e. `dunamai`) for vcs based dynamic versioning.

> Since 1.4.0 the meson dist command enables rewriting
> the build configuration of the distribution tarball.

see: https://mesonbuild.com/Creating-releases.html#cement-a-version-obtained-from-vcs