### PR TITLE
Add quilt patch set

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,37 +15,29 @@ defaults:
     shell: bash
 
 jobs:
-  svd-validation:
+  build:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      with:
-        fetch-depth: 0
     - name: install python requirements
       run: pip3 install -r requirements.txt
-    - name: xmlschema-validate
-      run: find . -iname "*.svd" | xargs xmlschema-validate --schema schema/CMSIS-SVD.xsd
-
-  svd-gen:
-    runs-on: [ubuntu-latest]
-    needs: svd-validation
-    strategy:
-      matrix:
-        operating_system: [ 'mesonbuild/fedora:latest', 'mesonbuild/ubuntu-rolling', 'mesonbuild/arch:latest', 'mesonbuild/opensuse:latest' ]
-      fail-fast: false
-    container:
-      image: ${{ matrix.operating_system }}
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      with:
-        fetch-depth: 0
-    - run: pip3 install -r requirements.txt
-    - name: Fixes dubious of git in github runners
+    - name: Meson Setup
       run: |
-        git config --global --add safe.directory '*'
-    - name: Meson build
+        meson setup -Dwith-test=true builddir
+    - name: Patch SVDs
       run: |
-        meson setup -Dwith-tests-only=true builddir
+        ninja -C builddir patch
+    - name: Validate SVDs
+      run: |
+        ninja -C builddir validate
+    - name: Generate Jsons
+      run: |
+        ninja -C builddir json
+    - name: Build tests
+      run: |
+        ninja -C builddir
+    - name: Run tests
+      run: |
         ninja -C builddir test
     - name: Meson postcheck
       if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 H2Lab Development Team
 **venv*
+
+# quilt metadata directories (authoring workflow at repo root)
+.pc/

--- a/README.md
+++ b/README.md
@@ -4,37 +4,62 @@ SPDX-FileCopyrightText: 2026 H2Lab Development Team
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# sentry-svd
+# KADOC, a SVD handling recipe for sentry kernel in meson
 Collection of SVD files with meson recipe to handle them
 
 [![REUSE status](https://github.com/camelot-os/kadoc/actions/workflows/reuse.yml/badge.svg?branch=main&event=push)](https://github.com/camelot-os/kadoc/actions/workflows/reuse.yml)
+
+## Overview
+
+Kadoc is Meson recipe that helps users to integrate SVD based code generation in their projects.
+It wraps the conversion from SVD to JSon using the python tools `svd2json` and provides a
+meson target for use as a meson subproject.
+SVD files are store under `svd/<manufacturer>/<soc>.svd`.
+
+Manufacturer SVD files under `svd/` are **immutable originals**, i.e. they must not
+be modified directly in source control.  Normalization and enrichment (fixing
+register-name prefixes, adding missing field enumerations, correcting widths,
+etc.) is tracked as a **quilt patch series** under `patches/<manufacturer>/<soc>/`.
+
+At build time Meson applies the series automatically using `support/meson/patch-apply.py`,
+which uses the standard POSIX `patch` utility, i.e. **no quilt dependency is required
+at build time**.  The patched SVD is produced in the build directory and never
+committed.  Ninja dependency tracking is handled through a generated depfile, so
+any change to the series file or any individual patch file triggers an incremental
+rebuild automatically.
 
 ## Prerequisits
 
 Python3 is required for this meson project with the following packages:
  - [Jinja2](https://pypi.org/project/Jinja2/)
  - [svd2json](https://pypi.org/project/svd2json/)
+ - [xmlschema](https://pypi.org/project/xmlschema/)
 
-## Project options
- - `svd`: string, svd filename to use (without `.svd` extension)
- The given file must be present under the `<project root>/svd` directory. The meson.build recipe will walk through the `svds` list.
+## Meson options
+ - <s>`svd`: string, svd filename to use (without `.svd` extension)
+ The given file must be present under the `<project root>/svd` directory. The meson.build recipe will walk through the `svds` list.</s> [DEPRECATED]
+ - <s>`with-tests-only`: boolean, with unittests, this disables the regular targets, use for test purpose
+ only </s> [DEPRECATED]
+ - `target`: target(s) list, comma separated, leave empty for all targets (default empty)
+ - `with-test`: boolean, if true, enable test build for each selected target (default false)
+ - `schema-validation`: feature, Add svd schema validation ninja target if enable (default auto)
 
  e.g.:
   ```console
-  meson setup -Dstm32u5xx <builddir>
+  meson setup -Dwith-test=true <builddir>
  ```
 
 ## Usage
-This project defines a custom target that convert the manufacturer provided svd to a custom json format to ease header generation with `Jinja2`, that target is named `<svd_basename>.json`
+This project defines a custom target that convert the manufacturer provided svd to a custom json format to ease header generation with `Jinja2`, that target is named `<soc>.json`
 
 ```console
 cd <builddir>
-ninja stm32u5xx.json
+ninja stm32u5a5.json
 ```
 
 ### As a subproject
 While use as a meson subproject, this project provides useful variables.
- - `svd_json`: targets that generates json file.
+ - `json_dict`: dictionary of targets that generates json file w/ soc name as key.
  - `jinja_cli`: program (found by `find_program`) to use with `custom_target` or `generator`.
  - `irq_defs_in`: template to generate soc irqs definition header.
  - `layout_in`: template to generate soc peripherals layout (IP base address) header.
@@ -47,32 +72,33 @@ While use as a meson subproject, this project provides useful variables.
  irq_def_h = custom_target('gen_irq_defs',
     input: irq_defs_in,
      output: '@BASENAME@',
-     depends: [ svd_json ],
-     command: [ jinja_cli, '-d', svd_json, '-o', '@OUTPUT@', '@INPUT@' ],
+     depends: [ json_dict['<soc>'] ],
+     command: [ jinja_cli, '-d', json_dict['<soc>'], '-o', '@OUTPUT@', '@INPUT@' ],
  )
 
  layout_h = custom_target('gen_layout',
      input: layout_in,
      output: '@BASENAME@',
-     depends: [ svd_json ],
-     command: [ jinja_cli, '-d', svd_json, '-o', '@OUTPUT@', '@INPUT@' ],
+     depends: [ json_dict['<soc>'] ],
+     command: [ jinja_cli, '-d', json_dict['<soc>'], '-o', '@OUTPUT@', '@INPUT@' ],
  )
 ```
  ##### with generator
 ```
 jinja_gen = generator(jinja_cli,
        output: '@BASENAME@',
-       arguments: ['-d', '@0@'.format(svd_json),
+       arguments: ['-d', '@0@'.format(json_dict['<soc>']),
                    '-o', '@OUTPUT@',
                    '@EXTRA_ARGS@',
                    '@INPUT@'],
-       depends: [ svd_json ])
+       depends: [ json_dict['<soc>'] ])
 
  irq_def_h = jinja_gen.process(irq_defs_in)
  layout_h = jinja_gen.process(layout_in)
  gpio_h = jinja_gen.process(peripheral_defs_in, extra_args: ['--define', 'NAME', 'GPIO'])
 ```
-> **NOTE:**  `NAME` value must be either a peripheral `name` **or** peripherals `groupName`
+> [!NOTE]
+> `NAME` value must be either a peripheral `name` **or** peripherals `groupName`
 
 ## LICENSE
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 H2Lab Development Team
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+# quilt patch series
+[[annotations]]
+path = "patches/**"
+SPDX-FileCopyrightText = "2026 H2Lab Development Team"
+SPDX-License-Identifier = "Apache-2.0"

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ py3 = pymod.find_installation('python3', modules: ['svd2json', 'jinja2'])
 svd2json = find_program('svd2json')
 jinja_cli = find_program('jinja')
 patch_apply = find_program('support/meson/patch-apply.py')
+xmlschema_validate = find_program('xmlschema-validate', required: get_option('schema-validation'))
 
 targets = get_option('target')
 with_test = get_option('with-test')
@@ -36,6 +37,7 @@ endif
 
 patched_dict = {}
 json_dict = {}
+validate = []
 
 foreach t: targets
     if not svd_dict.has_key(t)
@@ -67,6 +69,10 @@ foreach t: targets
         install_data(svd_in, install_dir : get_option('datadir') / svd_install_suffix)
     endif
 
+    if xmlschema_validate.found()
+        validate += run_target(t + '-validate', command: [xmlschema_validate, '--schema', schema_files, svd_in])
+    endif
+
     json = custom_target(t + '.json',
         input: svd_in,
         output: '@BASENAME@.json',
@@ -77,6 +83,9 @@ endforeach
 
 alias_target('patch', patched_dict.values())
 alias_target('json', json_dict.values())
+if xmlschema_validate.found()
+alias_target('validate', validate)
+endif
 
 if with_test
     subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -1,23 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2023 Ledger SAS
-# Copyright 2025 H2Lab
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 Ledger SAS
+# SPDX-FileCopyrightText: 2025 - 2026 H2Lab Development Team
 
 project(
     'kadoc', 'c',
-    meson_version: '>=1.4.0',
+    meson_version: '>=1.10.0',
     version : run_command('support/meson/version.sh', 'get-vcs', check: true).stdout().strip(),
     license: 'Apache-2.0',
     license_files: ['LICENSES/Apache-2.0.txt'],
@@ -26,31 +14,73 @@ project(
 meson.add_dist_script('support/meson/version.sh', 'set-dist', meson.project_version())
 
 pymod = import('python')
-fs = import('fs')
+
 py3 = pymod.find_installation('python3', modules: ['svd2json', 'jinja2'])
 
 svd2json = find_program('svd2json')
 jinja_cli = find_program('jinja')
+patch_apply = find_program('support/meson/patch-apply.py')
 
-svd_opt = get_option('svd')
+targets = get_option('target')
+with_test = get_option('with-test')
 
-subdir('template')
-subdir('svd')
+subdir('patches')
 subdir('schema')
+subdir('svd')
+subdir('template')
 
-if not get_option('with-tests-only')
-    foreach f : svd_files
-        if svd_opt == fs.stem(fs.name(f))
-            svd_input = f
-            break
-        endif
-    endforeach
+# If targets list is empty, defaulted to all svd files
+if targets.length() == 0
+    targets = svd_dict.keys()
+endif
 
-    svd_json = custom_target('System View Description in json',
-        input: svd_input,
+patched_dict = {}
+json_dict = {}
+
+foreach t: targets
+    if not svd_dict.has_key(t)
+        error('target', t, 'not found')
+    endif
+
+    svd_in = svd_dict.get(t)
+    # SVD install directory is '<prefix>/share/svd/<manufacturer>'
+    # So, deduce here the 'svd/<manufacturer>' for each svd
+    svd_install_suffix = fs.parent(fs.relative_to(svd_in, meson.current_source_dir()))
+
+    if patch_series_dict.has_key(t)
+        series = patch_series_dict.get(t)
+        # If SVD is patched, install the original svd renamed <target>.svd -> <target>.orig.svd
+        install_orig_svd = fs.name(fs.replace_suffix(svd_in, '.orig.svd'))
+        install_data(svd_in, install_dir : get_option('datadir') / svd_install_suffix, rename: install_orig_svd)
+        svd_in = custom_target(
+            t + '.svd patched',
+            input: svd_in,
+            output: '@BASENAME@.svd',
+            depfile: '@BASENAME@.d',
+            depend_files: series,
+            command: [patch_apply, '@INPUT@', series, '@OUTPUT@', '@DEPFILE@'],
+            install: true,
+            install_dir: get_option('datadir') / svd_install_suffix,
+        )
+        patched_dict += {t: svd_in}
+    else
+        install_data(svd_in, install_dir : get_option('datadir') / svd_install_suffix)
+    endif
+
+    json = custom_target(t + '.json',
+        input: svd_in,
         output: '@BASENAME@.json',
         command: [ svd2json, '--svd', '@INPUT@', '@OUTPUT@' ],
     )
-else
+    json_dict += {t: json}
+endforeach
+
+alias_target('patch', patched_dict.values())
+alias_target('json', json_dict.values())
+
+if with_test
     subdir('tests')
 endif
+
+summary('target', patched_dict.keys(), section: 'Patched SVD')
+summary('target', json_dict.keys(), section: 'Generated Json')

--- a/meson.options
+++ b/meson.options
@@ -24,3 +24,4 @@ deprecated: 'with-test')
 
 option('target', type: 'array', value: [], description: 'list of target svd files to process, empty list means all')
 option('with-test', type: 'boolean', value: false, description: 'Execute auto generated test for given targets')
+option('schema-validation', type: 'feature', value: 'auto', description: 'validate svd against XML schema')

--- a/meson.options
+++ b/meson.options
@@ -14,7 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-option('svd', type: 'string', value: 'stm32u5a5', description: 'svd filename to use (without .svd extension')
+option('svd', type: 'string', description: 'svd filename to use (without .svd extension',
+ deprecated: 'target')
+
 option('with-tests-only', type: 'boolean', value: false, description:
 'with unittests, this disables the regular targets,' +
-'use for test purpose only')
+'use for test purpose only',
+deprecated: 'with-test')
+
+option('target', type: 'array', value: [], description: 'list of target svd files to process, empty list means all')
+option('with-test', type: 'boolean', value: false, description: 'Execute auto generated test for given targets')

--- a/patches/meson.build
+++ b/patches/meson.build
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 H2Lab Development Team
+
+fs = import('fs')
+
+patch_series_files = files()
+
+subdir('st')
+
+# Create a dictionary w/ target as key, patch series file object as value
+patch_series_dict = {}
+foreach f: patch_series_files
+    # patches layout is the following, patches/<manufacturer>/<target>/series
+    target = fs.name(fs.parent(f))
+    patch_series_dict += {target: f}
+endforeach

--- a/patches/st/meson.build
+++ b/patches/st/meson.build
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: 2026 H2Lab Development Team
+
+patch_series_files += files(
+    'stm32u5a5/series',
+)

--- a/patches/st/stm32u5a5/0001-rcc-strip-register-name-prefix.patch
+++ b/patches/st/stm32u5a5/0001-rcc-strip-register-name-prefix.patch
@@ -1,0 +1,470 @@
+--- a/stm32u5a5.svd
++++ b/stm32u5a5.svd
+@@ -190320,7 +190320,7 @@
+       </interrupt>
+       <registers>
+           <register>
+-            <name>RCC_CR</name>
++            <name>CR</name>
+             <displayName>RCC_CR</displayName>
+             <description>RCC clock control register</description>
+             <addressOffset>0x000</addressOffset>
+@@ -190861,7 +190861,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_ICSCR1</name>
++            <name>ICSCR1</name>
+             <displayName>RCC_ICSCR1</displayName>
+             <description>RCC internal clock sources calibration register 1</description>
+             <addressOffset>0x008</addressOffset>
+@@ -191133,7 +191133,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_ICSCR2</name>
++            <name>ICSCR2</name>
+             <displayName>RCC_ICSCR2</displayName>
+             <description>RCC internal clock sources calibration register 2</description>
+             <addressOffset>0x00C</addressOffset>
+@@ -191176,7 +191176,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_ICSCR3</name>
++            <name>ICSCR3</name>
+             <displayName>RCC_ICSCR3</displayName>
+             <description>RCC internal clock sources calibration register 3</description>
+             <addressOffset>0x010</addressOffset>
+@@ -191203,7 +191203,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CRRCR</name>
++            <name>CRRCR</name>
+             <displayName>RCC_CRRCR</displayName>
+             <description>RCC clock recovery RC register</description>
+             <addressOffset>0x014</addressOffset>
+@@ -191222,7 +191222,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CFGR1</name>
++            <name>CFGR1</name>
+             <displayName>RCC_CFGR1</displayName>
+             <description>RCC clock configuration register 1</description>
+             <addressOffset>0x01C</addressOffset>
+@@ -191432,7 +191432,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CFGR2</name>
++            <name>CFGR2</name>
+             <displayName>RCC_CFGR2</displayName>
+             <description>RCC clock configuration register 2</description>
+             <addressOffset>0x020</addressOffset>
+@@ -191689,7 +191689,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CFGR3</name>
++            <name>CFGR3</name>
+             <displayName>RCC_CFGR3</displayName>
+             <description>RCC clock configuration register 3</description>
+             <addressOffset>0x024</addressOffset>
+@@ -191771,7 +191771,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL1CFGR</name>
++            <name>PLL1CFGR</name>
+             <displayName>RCC_PLL1CFGR</displayName>
+             <description>RCC PLL1 configuration register</description>
+             <addressOffset>0x028</addressOffset>
+@@ -191985,7 +191985,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL2CFGR</name>
++            <name>PLL2CFGR</name>
+             <displayName>RCC_PLL2CFGR</displayName>
+             <description>RCC PLL2 configuration register</description>
+             <addressOffset>0x02C</addressOffset>
+@@ -192142,7 +192142,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL3CFGR</name>
++            <name>PLL3CFGR</name>
+             <displayName>RCC_PLL3CFGR</displayName>
+             <description>RCC PLL3 configuration register</description>
+             <addressOffset>0x030</addressOffset>
+@@ -192298,7 +192298,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL1DIVR</name>
++            <name>PLL1DIVR</name>
+             <displayName>RCC_PLL1DIVR</displayName>
+             <description>RCC PLL1 dividers register</description>
+             <addressOffset>0x034</addressOffset>
+@@ -192458,7 +192458,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL1FRACR</name>
++            <name>PLL1FRACR</name>
+             <displayName>RCC_PLL1FRACR</displayName>
+             <description>RCC PLL1 fractional divider register</description>
+             <addressOffset>0x038</addressOffset>
+@@ -192485,7 +192485,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL2DIVR</name>
++            <name>PLL2DIVR</name>
+             <displayName>RCC_PLL2DIVR</displayName>
+             <description>RCC PLL2 dividers configuration register</description>
+             <addressOffset>0x03C</addressOffset>
+@@ -192645,7 +192645,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL2FRACR</name>
++            <name>PLL2FRACR</name>
+             <displayName>RCC_PLL2FRACR</displayName>
+             <description>RCC PLL2 fractional divider register</description>
+             <addressOffset>0x040</addressOffset>
+@@ -192672,7 +192672,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL3DIVR</name>
++            <name>PLL3DIVR</name>
+             <displayName>RCC_PLL3DIVR</displayName>
+             <description>RCC PLL3 dividers configuration register</description>
+             <addressOffset>0x044</addressOffset>
+@@ -192832,7 +192832,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PLL3FRACR</name>
++            <name>PLL3FRACR</name>
+             <displayName>RCC_PLL3FRACR</displayName>
+             <description>RCC PLL3 fractional divider register</description>
+             <addressOffset>0x048</addressOffset>
+@@ -192859,7 +192859,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CIER</name>
++            <name>CIER</name>
+             <displayName>RCC_CIER</displayName>
+             <description>RCC clock interrupt enable register</description>
+             <addressOffset>0x050</addressOffset>
+@@ -193090,7 +193090,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CIFR</name>
++            <name>CIFR</name>
+             <displayName>RCC_CIFR</displayName>
+             <description>RCC clock interrupt flag register</description>
+             <addressOffset>0x054</addressOffset>
+@@ -193341,7 +193341,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CICR</name>
++            <name>CICR</name>
+             <displayName>RCC_CICR</displayName>
+             <description>RCC clock interrupt clear register</description>
+             <addressOffset>0x058</addressOffset>
+@@ -193448,7 +193448,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB1RSTR</name>
++            <name>AHB1RSTR</name>
+             <displayName>RCC_AHB1RSTR</displayName>
+             <description>RCC AHB1 peripheral reset register</description>
+             <addressOffset>0x060</addressOffset>
+@@ -193683,7 +193683,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2RSTR1</name>
++            <name>AHB2RSTR1</name>
+             <displayName>RCC_AHB2RSTR1</displayName>
+             <description>RCC AHB2 peripheral reset register 1</description>
+             <addressOffset>0x064</addressOffset>
+@@ -194167,7 +194167,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2RSTR2</name>
++            <name>AHB2RSTR2</name>
+             <displayName>RCC_AHB2RSTR2</displayName>
+             <description>RCC AHB2 peripheral reset register 2</description>
+             <addressOffset>0x068</addressOffset>
+@@ -194261,7 +194261,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB3RSTR</name>
++            <name>AHB3RSTR</name>
+             <displayName>RCC_AHB3RSTR</displayName>
+             <description>RCC AHB3 peripheral reset register</description>
+             <addressOffset>0x06C</addressOffset>
+@@ -194372,7 +194372,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1RSTR1</name>
++            <name>APB1RSTR1</name>
+             <displayName>RCC_APB1RSTR1</displayName>
+             <description>RCC APB1 peripheral reset register 1</description>
+             <addressOffset>0x074</addressOffset>
+@@ -194685,7 +194685,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1RSTR2</name>
++            <name>APB1RSTR2</name>
+             <displayName>RCC_APB1RSTR2</displayName>
+             <description>RCC APB1 peripheral reset register 2</description>
+             <addressOffset>0x078</addressOffset>
+@@ -194819,7 +194819,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB2RSTR</name>
++            <name>APB2RSTR</name>
+             <displayName>RCC_APB2RSTR</displayName>
+             <description>RCC APB2 peripheral reset register</description>
+             <addressOffset>0x07C</addressOffset>
+@@ -195095,7 +195095,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB3RSTR</name>
++            <name>APB3RSTR</name>
+             <displayName>RCC_APB3RSTR</displayName>
+             <description>RCC APB3 peripheral reset register</description>
+             <addressOffset>0x080</addressOffset>
+@@ -195306,7 +195306,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB1ENR</name>
++            <name>AHB1ENR</name>
+             <displayName>RCC_AHB1ENR</displayName>
+             <description>RCC AHB1 peripheral clock enable register</description>
+             <addressOffset>0x088</addressOffset>
+@@ -195664,7 +195664,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2ENR1</name>
++            <name>AHB2ENR1</name>
+             <displayName>RCC_AHB2ENR1</displayName>
+             <description>RCC AHB2 peripheral clock enable register 1</description>
+             <addressOffset>0x08C</addressOffset>
+@@ -196209,7 +196209,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2ENR2</name>
++            <name>AHB2ENR2</name>
+             <displayName>RCC_AHB2ENR2</displayName>
+             <description>RCC AHB2 peripheral clock enable register 2</description>
+             <addressOffset>0x090</addressOffset>
+@@ -196345,7 +196345,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB3ENR</name>
++            <name>AHB3ENR</name>
+             <displayName>RCC_AHB3ENR</displayName>
+             <description>RCC AHB3 peripheral clock enable register</description>
+             <addressOffset>0x094</addressOffset>
+@@ -196516,7 +196516,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1ENR1</name>
++            <name>APB1ENR1</name>
+             <displayName>RCC_APB1ENR1</displayName>
+             <description>RCC APB1 peripheral clock enable register 1</description>
+             <addressOffset>0x09C</addressOffset>
+@@ -196849,7 +196849,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1ENR2</name>
++            <name>APB1ENR2</name>
+             <displayName>RCC_APB1ENR2</displayName>
+             <description>RCC APB1 peripheral clock enable register 2</description>
+             <addressOffset>0x0A0</addressOffset>
+@@ -196983,7 +196983,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB2ENR</name>
++            <name>APB2ENR</name>
+             <displayName>RCC_APB2ENR</displayName>
+             <description>RCC APB2 peripheral clock enable register</description>
+             <addressOffset>0x0A4</addressOffset>
+@@ -197259,7 +197259,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB3ENR</name>
++            <name>APB3ENR</name>
+             <displayName>RCC_APB3ENR</displayName>
+             <description>RCC APB3 peripheral clock enable register</description>
+             <addressOffset>0x0A8</addressOffset>
+@@ -197490,7 +197490,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB1SMENR</name>
++            <name>AHB1SMENR</name>
+             <displayName>RCC_AHB1SMENR</displayName>
+             <description>RCC AHB1 peripheral clock enable in Sleep and Stop modes register</description>
+             <addressOffset>0x0B0</addressOffset>
+@@ -197868,7 +197868,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2SMENR1</name>
++            <name>AHB2SMENR1</name>
+             <displayName>RCC_AHB2SMENR1</displayName>
+             <description>RCC AHB2 peripheral clock enable in Sleep and	Stop modes register 1</description>
+             <addressOffset>0x0B4</addressOffset>
+@@ -198413,7 +198413,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB2SMENR2</name>
++            <name>AHB2SMENR2</name>
+             <displayName>RCC_AHB2SMENR2</displayName>
+             <description>RCC AHB2 peripheral clock enable in Sleep and	Stop modes register 2</description>
+             <addressOffset>0x0B8</addressOffset>
+@@ -198549,7 +198549,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_AHB3SMENR</name>
++            <name>AHB3SMENR</name>
+             <displayName>RCC_AHB3SMENR</displayName>
+             <description>RCC AHB3 peripheral clock enable in Sleep and Stop modes register</description>
+             <addressOffset>0x0BC</addressOffset>
+@@ -198724,7 +198724,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1SMENR1</name>
++            <name>APB1SMENR1</name>
+             <displayName>RCC_APB1SMENR1</displayName>
+             <description>RCC APB1 peripheral clock enable in Sleep and Stop modes	register 1</description>
+             <addressOffset>0x0C4</addressOffset>
+@@ -199065,7 +199065,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB1SMENR2</name>
++            <name>APB1SMENR2</name>
+             <displayName>RCC_APB1SMENR2</displayName>
+             <description>RCC APB1 peripheral clocks enable in Sleep and	Stop modes register 2</description>
+             <addressOffset>0x0C8</addressOffset>
+@@ -199203,7 +199203,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB2SMENR</name>
++            <name>APB2SMENR</name>
+             <displayName>RCC_APB2SMENR</displayName>
+             <description>RCC APB2 peripheral clocks enable in Sleep and Stop modes register</description>
+             <addressOffset>0x0CC</addressOffset>
+@@ -199481,7 +199481,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_APB3SMENR</name>
++            <name>APB3SMENR</name>
+             <displayName>RCC_APB3SMENR</displayName>
+             <description>RCC APB3 peripheral clock enable in Sleep and Stop modes register</description>
+             <addressOffset>0x0D0</addressOffset>
+@@ -199719,7 +199719,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_SRDAMR</name>
++            <name>SRDAMR</name>
+             <displayName>RCC_SRDAMR</displayName>
+             <description>RCC SmartRun domain peripheral autonomous mode register</description>
+             <addressOffset>0x0D8</addressOffset>
+@@ -200061,7 +200061,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CCIPR1</name>
++            <name>CCIPR1</name>
+             <displayName>RCC_CCIPR1</displayName>
+             <description>RCC peripherals independent clock configuration register 1</description>
+             <addressOffset>0x0E0</addressOffset>
+@@ -200538,7 +200538,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CCIPR2</name>
++            <name>CCIPR2</name>
+             <displayName>RCC_CCIPR2</displayName>
+             <description>RCC peripherals independent clock configuration register 2</description>
+             <addressOffset>0x0E4</addressOffset>
+@@ -200963,7 +200963,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CCIPR3</name>
++            <name>CCIPR3</name>
+             <displayName>RCC_CCIPR3</displayName>
+             <description>RCC peripherals independent clock configuration register 3</description>
+             <addressOffset>0x0E8</addressOffset>
+@@ -201234,7 +201234,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_BDCR</name>
++            <name>BDCR</name>
+             <displayName>RCC_BDCR</displayName>
+             <description>RCC backup domain control register</description>
+             <addressOffset>0x00F0</addressOffset>
+@@ -201609,7 +201609,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_CSR</name>
++            <name>CSR</name>
+             <displayName>RCC_CSR</displayName>
+             <description>RCC control/status register</description>
+             <addressOffset>0x0F4</addressOffset>
+@@ -201854,7 +201854,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_SECCFGR</name>
++            <name>SECCFGR</name>
+             <displayName>RCC_SECCFGR</displayName>
+             <description>RCC secure configuration register</description>
+             <addressOffset>0x110</addressOffset>
+@@ -202125,7 +202125,7 @@
+             </fields>
+           </register>
+           <register>
+-            <name>RCC_PRIVCFGR</name>
++            <name>PRIVCFGR</name>
+             <displayName>RCC_PRIVCFGR</displayName>
+             <description>RCC privilege configuration register</description>
+             <addressOffset>0x114</addressOffset>

--- a/patches/st/stm32u5a5/series
+++ b/patches/st/stm32u5a5/series
@@ -1,0 +1,9 @@
+# Patch series for stm32u5a5
+#
+# Naming convention: NNNN-verb-peripheral-description.patch
+#
+# NOTE: if the manufacturer SVD requires formatting, 0001-format.patch
+#       MUST be the first entry so all subsequent patches are human-readable.
+#       stm32u5a5.svd is already consistently formatted; no format patch needed.
+
+0001-rcc-strip-register-name-prefix.patch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2024 Ledger SAS
-# SPDX-FileCopyrightText: 2025 H2Lab
+# SPDX-FileCopyrightText: 2025 - 2026 H2Lab Development Team
 #
 # SPDX-License-Identifier: Apache-2.0
 
-meson
+meson>=1.10
 xmlschema
 svd2json>=0.1.6
 jinja2

--- a/support/meson/patch-apply.py
+++ b/support/meson/patch-apply.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 H2Lab Development Team
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Apply a quilt-compatible patch series to an SVD file and emit a Ninja depfile.
+
+Usage:
+    patch-apply.py <orig_svd> <series> <output_svd> <depfile>
+
+Arguments:
+    orig_svd     Path to the original (unmodified) manufacturer SVD file.
+    series       Path to the patch series directory containing a 'series' file
+                 and the individual .patch files listed in it.
+    output_svd   Path where the patched SVD will be written (in builddir).
+    depfile      Path where the Ninja depfile will be written.  Meson passes
+                 this as @DEPFILE@ from the calling custom_target.
+
+The script uses the standard POSIX `patch` utility - no quilt dependency is
+required at build time. quilt is only needed for authoring new patches.
+
+Depfile format (Ninja make-style):
+    <output_svd>: <patch1> <patch2> ...
+
+Orig svd and and patch series file are already mark as dependencies by meson as
+they are (implicit) inputs.
+"""
+
+import shutil
+import subprocess
+import sys
+
+from pathlib import Path
+
+
+PATCH_CMD = shutil.which("patch")
+
+
+def read_series(series: Path) -> list[Path]:
+    """Return list of patch filenames from a quilt series file (comments stripped)."""
+    parent_dir = series.parent
+    patches = []
+    with series.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                # quilt series entries may have options after the filename; take first token
+                patches.append(Path(parent_dir / line.split()[0]))
+    return patches
+
+
+def apply_patch(patch: Path, workdir: Path) -> None:
+    result = subprocess.run(
+        [
+            PATCH_CMD,
+            '--no-backup-if-mismatch',
+            '--reject-file=-',
+            '--binary',
+            '-p1',
+            '--input', str(patch),
+        ],
+        cwd=workdir,
+    )
+    if result.returncode != 0:
+        print(f'error: patch failed: {patch}', file=sys.stderr)
+        sys.exit(result.returncode)
+
+
+def write_depfile(depfile: Path, output: Path, deps: list[Path]) -> None:
+    with depfile.open('w', encoding="utf-8") as f:
+        f.write(f"{str(output)}: ")
+        f.writelines([f"{str(d)} \\" for d in deps])
+
+
+def main() -> int:
+    if not PATCH_CMD:
+        print('error: patch command not found', file=sys.stderr)
+        return 1
+
+    if len(sys.argv) != 5:
+        print(
+            f'usage: {sys.argv[0]} <orig_svd> <series> <output_svd> <depfile>',
+            file=sys.stderr,
+        )
+        return 1
+
+    orig_svd   = Path(sys.argv[1]).absolute()
+    series     = Path(sys.argv[2]).absolute()
+    output_svd = Path(sys.argv[3]).absolute()
+    depfile    = Path(sys.argv[4]).absolute()
+
+    patches = read_series(series)
+
+    # Verify all patches exist before starting
+    for p in patches:
+        if not p.is_file():
+            print(f'error: patch not found: {p}', file=sys.stderr)
+            return 1
+
+    shutil.copy2(orig_svd, output_svd)
+    for patch in patches:
+        apply_patch(patch, output_svd.parent)
+
+    write_depfile(depfile, output_svd, patches)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/svd/meson.build
+++ b/svd/meson.build
@@ -1,18 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2023 Ledger SAS
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 Ledger SAS
+# SPDX-FileCopyrightText: 2026 H2Lab Development Team
+
+fs = import('fs')
 
 svd_files = files()
 
@@ -20,3 +11,10 @@ svd_files = files()
 subdir('st')
 # NOTE: Raspberry pi not yet being supported, it is not included as the rpi SVD file
 # is not, by now, valid
+
+# Create a dictionary w/ target as key, svd file object as value
+svd_dict = {}
+foreach f: svd_files
+    target = fs.stem(fs.name(f))
+    svd_dict += {target: f}
+endforeach

--- a/svd/st/meson.build
+++ b/svd/st/meson.build
@@ -79,9 +79,3 @@ svd_files += files(
     'stm32wl5x_cm4.svd',
     'stm32wle5_cm4.svd',
 )
-
-
-install_data(
-  svd_files,
-  install_dir :  get_option('datadir') + '/svd/st'
-)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,19 +24,7 @@ svd_tests_peripherals = [
     'SPI',
 ]
 
-svd_tested_soc = []
-
-foreach f: svd_files
-    soc = fs.stem(fs.name(f))
-
-    svd_tested_soc += soc
-
-    svd_json = custom_target('System View Description @0@ json'.format(soc),
-        input: f,
-        output: '@BASENAME@.json',
-        command: [ svd2json, '--svd', '@INPUT@', '@OUTPUT@' ],
-    )
-
+foreach soc, svd_json: json_dict
     irq_defs_h = custom_target('@0@_irq_defs_h'.format(soc),
         input: irq_defs_in,
         output: '@0@_@BASENAME@'.format(soc),
@@ -80,5 +68,3 @@ foreach f: svd_files
     test('@0@'.format(soc), test_exe)
 
 endforeach
-
-summary('Verified soc(s)', svd_tested_soc)


### PR DESCRIPTION
Add Quilt patchset handling.

- [x] Patch SVD if patch series exists
- [x] Install SVD and Patched ones (orig svd are install w/ .orig suffix)
- [ ] Generate some patch for used target.
- [x] Add xml schema validation to meson recipe
- [ ] Add some agent skill for svd fixup automation (gen patch series, update, etc.)

Current state:
 The only patch is for devel only, it will be regen properly once ready to merge.